### PR TITLE
Allow psr/log version 2.x and 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-dom": "*",
         "ext-xml": "*",
         "ext-mbstring": "*",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "masterminds/html5": "^2.0",
         "league/uri": "~6.7.2"
     },


### PR DESCRIPTION
The psr/log library was tagged with versions 2.0.0 and 3.0.0 back in 2021. This PR allows to use these versions in readability.