### PR TITLE
Support other psr/log versions as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-dom": "*",
         "ext-xml": "*",
         "ext-mbstring": "*",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "masterminds/html5": "^2.0",
         "league/uri": "~6.7.2"
     },


### PR DESCRIPTION
This pull request implements support for `psr/log` versions 2 and 3. 

Locking this package to v1 prevents it from being used in newer Laravel applications. This pull request resolves that.