### PR TITLE
fix: allow DOMProcessingInstruction in Readability and NodeUtility

### DIFF
--- a/src/Nodes/NodeUtility.php
+++ b/src/Nodes/NodeUtility.php
@@ -5,6 +5,7 @@ namespace fivefilters\Readability\Nodes;
 use fivefilters\Readability\Nodes\DOM\DOMDocument;
 use fivefilters\Readability\Nodes\DOM\DOMElement;
 use fivefilters\Readability\Nodes\DOM\DOMNode;
+use fivefilters\Readability\Nodes\DOM\DOMProcessingInstruction;
 use fivefilters\Readability\Nodes\DOM\DOMText;
 use fivefilters\Readability\Nodes\DOM\DOMComment;
 use fivefilters\Readability\Nodes\DOM\DOMNodeList;
@@ -120,7 +121,7 @@ class NodeUtility
      * Returns the next node. First checks for children (if the flag allows it), then for siblings, and finally
      * for parents.
      */
-    public static function getNextNode(DOMNode|DOMComment|DOMText|DOMElement|DOMDocument $originalNode, bool $ignoreSelfAndKids = false): DOMNode|DOMComment|DOMText|DOMElement|DOMDocument|null
+    public static function getNextNode(DOMNode|DOMComment|DOMText|DOMElement|DOMDocument|DOMProcessingInstruction $originalNode, bool $ignoreSelfAndKids = false): DOMNode|DOMComment|DOMText|DOMElement|DOMDocument|DOMProcessingInstruction|null
     {
         /*
          * Traverse the DOM from node to node, starting at the node passed in.

--- a/src/Readability.php
+++ b/src/Readability.php
@@ -5,6 +5,7 @@ namespace fivefilters\Readability;
 use fivefilters\Readability\Nodes\DOM\DOMDocument;
 use fivefilters\Readability\Nodes\DOM\DOMElement;
 use fivefilters\Readability\Nodes\DOM\DOMNode;
+use fivefilters\Readability\Nodes\DOM\DOMProcessingInstruction;
 use fivefilters\Readability\Nodes\DOM\DOMText;
 use fivefilters\Readability\Nodes\DOM\DOMComment;
 use fivefilters\Readability\Nodes\NodeUtility;
@@ -391,7 +392,7 @@ class Readability
                 return $metadata;
             } catch (\Exception $err) {
                 // The try-catch blocks are from the JS version. Not sure if there's anything
-                // here in the PHP version that would trigger an error or exception, so perhaps we can 
+                // here in the PHP version that would trigger an error or exception, so perhaps we can
                 // remove the try-catch blocks here (or at least translate errors to exceptions for this bit)
                 $this->logger->debug('[JSON-LD] Error parsing: ' . $err->getMessage());
             }
@@ -418,7 +419,7 @@ class Readability
             /* @var DOMNode $meta */
             $elementName = $meta->getAttribute('name');
             $elementProperty = $meta->getAttribute('property');
-            $content = $meta->getAttribute('content'); 
+            $content = $meta->getAttribute('content');
             $matches = null;
             $name = null;
 
@@ -960,7 +961,7 @@ class Readability
     /**
      * Checks if the node is a byline.
      */
-    private function checkByline(DOMNode|DOMText|DOMElement $node, string $matchString): bool
+    private function checkByline(DOMNode|DOMText|DOMElement|DOMProcessingInstruction $node, string $matchString): bool
     {
         if (!$this->configuration->getArticleByline()) {
             return false;
@@ -2043,7 +2044,7 @@ class Readability
      * @param DOMNode the node to check.
      * @return boolean indicating whether this is a title-like header.
      */
-    private function headerDuplicatesTitle(DOMNode|DOMText|DOMElement $node): bool
+    private function headerDuplicatesTitle(DOMNode|DOMText|DOMElement|DOMProcessingInstruction $node): bool
     {
         if ($node->nodeName !== 'h1' && $node->nodeName !== 'h2') {
             return false;


### PR DESCRIPTION
Naive potential fix for #35 

With the changes the puny script runs throughs and exits with 0.

I don't know whether this has any other implications, it's just the first time looking into this repo. But maybe it would be simpler to have the allowed node elements implementing an interface.

@fivefilters for your evaluation