### PR TITLE
Defer innerHTML serialization in the "Grabbed" debug log

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -207,7 +207,7 @@ final class Readability
                 );
             }
 
-            $this->log('Grabbed: ' . $articleContent->innerHTML);
+            $this->log('Grabbed:', fn (): string => $articleContent->innerHTML);
 
             $this->postProcessContent($articleContent);
 
@@ -2566,6 +2566,12 @@ final class Readability
             return;
         }
         $format = function (mixed $arg): string {
+            // Closures defer expensive serialization (e.g. a large innerHTML)
+            // until here, past the enabled check above, so nothing is built
+            // when logging is off.
+            if ($arg instanceof \Closure) {
+                $arg = $arg();
+            }
             if ($arg instanceof \Dom\Element) {
                 $attrPairs = [];
                 foreach ($arg->attributes as $attr) {


### PR DESCRIPTION
## What

`grabArticle()` logged the grabbed article with:

```php
$this->log('Grabbed: ' . $articleContent->innerHTML);
```

PHP evaluates function arguments eagerly, so `innerHTML` serialized the entire article subtree into a string on **every** parse — even when no logger was configured and `debug` was off. `log()`'s early return then discarded it. The serialization work (and a large transient allocation) happened before `log()` was ever entered.

This changes the call site to pass a closure, and teaches `log()`'s formatter to resolve any `\Closure` argument — but only after the enabled check that guards the method:

```php
$this->log('Grabbed:', fn (): string => $articleContent->innerHTML);
```

When logging is off, the closure is never invoked and `innerHTML` is never built. When logging is on, the emitted message is byte-for-byte identical to before.

## Why a closure, not a change to the element formatter

The formatter's `\Dom\Element` branch is shared by ~12 other call sites (`Candidate:`, `Looking at sibling node:`, `setNodeTag`, `Cleaning Conditionally`, …), many inside hot per-node loops. They rely on the compact `<div class="...">` representation. Emitting `innerHTML` for all elements would flood those logs with unreadable full-subtree dumps. Deferring via a closure scopes the change to this one line and leaves every other element log untouched. The formatter now also resolves closures generically, so other sites can defer expensive values the same way.

## Testing

Verified with a standalone script (composer/phpunit unavailable in this environment):

- **Behavior unchanged**: a real `parse()` with a PSR-3 logger emits exactly one `Grabbed:` message containing the serialized `innerHTML`.
- **Deferral works**: reproducing `log()`'s structure with a counting closure, the closure is invoked 0 times when logging is off and once when a logger is present.

`php -l` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXHSUavFZ8SkC5kX6j59BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXHSUavFZ8SkC5kX6j59BV)_