### PR TITLE
Widen dependency constraints for better co-installability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.4', '8.5']
+        dependencies: [highest, lowest]
 
     steps:
       - uses: actions/checkout@v7
@@ -25,11 +26,17 @@ jobs:
           extensions: dom, mbstring
           tools: composer:v2
 
-      - name: Install dependencies
-        run: composer install
+      - name: Install dependencies (highest)
+        if: matrix.dependencies == 'highest'
+        run: composer update --no-interaction
+
+      - name: Install dependencies (lowest)
+        if: matrix.dependencies == 'lowest'
+        run: composer update --no-interaction --prefer-lowest --prefer-stable
 
       - name: Run tests
         run: ./vendor/bin/phpunit
 
       - name: Static analysis
+        if: matrix.dependencies == 'highest'
         run: ./vendor/bin/psalm --output-format=github --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [v4.0.0](https://github.com/fivefilters/readability.php/releases/tag/v4.0.0)
+
+First stable release of the 4.0 series — a ground-up rewrite. This release includes **all changes from [v4.0.0-beta.1](https://github.com/fivefilters/readability.php/releases/tag/v4.0.0-beta.1) below** (see [UPGRADE.md](UPGRADE.md) for the 3.x → 4.0 migration guide), plus the following changes since beta.1:
 
 ### Changed
 - Widened dependency constraints so the library co-installs with a broader range of applications: `psr/log` now accepts `^1.0 || ^2.0 || ^3.0` (the library only consumes the interface, so every major works) and `rowbot/url` now accepts `^3.1.7 || ^4.0` (older majors avoid rowbot/url 4.x's hard requirements on `psr/log ^3` and newer `brick/math`, both common sources of version conflicts). Note: rowbot/url 3.x emits PHP 8.4 implicit-nullable deprecation notices internally; it is only loaded on PHP 8.4 (PHP 8.5+ uses the native `Uri\WhatWg\Url`), and Composer still picks 4.x unless another dependency forces an older version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Widened dependency constraints so the library co-installs with a broader range of applications: `psr/log` now accepts `^1.0 || ^2.0 || ^3.0` (the library only consumes the interface, so every major works) and `rowbot/url` now accepts `^3.1.7 || ^4.0` (older majors avoid rowbot/url 4.x's hard requirements on `psr/log ^3` and newer `brick/math`, both common sources of version conflicts). Note: rowbot/url 3.x emits PHP 8.4 implicit-nullable deprecation notices internally; it is only loaded on PHP 8.4 (PHP 8.5+ uses the native `Uri\WhatWg\Url`), and Composer still picks 4.x unless another dependency forces an older version
+- CI now also runs the test suite against the lowest allowed dependency versions (`composer update --prefer-lowest`) to keep the widened constraints honest
+
 ## [v4.0.0-beta.1](https://github.com/fivefilters/readability.php/releases/tag/v4.0.0-beta.1)
 
 Ground-up port from the latest Readability.js (v0.6.0) using Claude's Fable model. Uses PHP 8.4's new DOM API and native parser. See [UPGRADE.md](UPGRADE.md) for the full 3.x → 4.0 migration guide.

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "php": ">=8.4",
         "ext-dom": "*",
         "ext-mbstring": "*",
-        "psr/log": "^2.0 || ^3.0",
-        "rowbot/url": "^4.1"
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "rowbot/url": "^3.1.7 || ^4.0"
     },
     "suggest": {
         "ext-uri": "Native WHATWG URL parsing, used automatically on PHP 8.5+ instead of rowbot/url"

--- a/test/PhpFeaturesTest.php
+++ b/test/PhpFeaturesTest.php
@@ -107,7 +107,8 @@ class PhpFeaturesTest extends TestCase
             /** @var list<string> */
             public array $messages = [];
 
-            public function log($level, string|\Stringable $message, array $context = []): void
+            // Untyped $level/$message keep this compatible with every psr/log major (v1 has no parameter types).
+            public function log($level, $message, array $context = []): void
             {
                 $this->messages[] = (string) $message;
             }


### PR DESCRIPTION
Makes it easier to install readability.php into applications whose other dependencies pin different versions of our (transitive) dependencies, without changing the PHP minimum or the versions Composer installs by default.

## What changed

- **`psr/log`: `^2.0 || ^3.0` → `^1.0 || ^2.0 || ^3.0`.** The library only *consumes* `LoggerInterface` (a nullable constructor option and `$logger?->debug()` calls); it never implements it, so every major works. The anonymous logger in `PhpFeaturesTest` now uses an untyped `log()` signature that is valid against all three majors (the previous typed signature fatals under psr/log 1.x).
- **`rowbot/url`: `^4.1` → `^3.1.7 || ^4.0`.** rowbot/url 4.1 hard-requires `psr/log ^3.0` and `brick/math ^0.12 || ^0.13` — both frequent conflict sources in host apps (e.g. older `ramsey/uuid` pins older brick/math, and the psr/log ^3 requirement made our own `^2.0` alternative unsatisfiable in practice). Allowing 4.0 and 3.1.7 gives Composer's solver room; nothing changes for apps without conflicts, since Composer still resolves to the newest allowed version.
- **CI** now runs the test suite against both `highest` and `lowest` resolved dependencies (`composer update --prefer-lowest --prefer-stable`) on PHP 8.4 and 8.5, so the advertised lower bounds stay tested. Psalm still runs on highest only.
- **CHANGELOG**: Unreleased entry describing the above.

## Verification

Full suite (485 tests, 1080 assertions) plus Psalm run locally on PHP 8.4 (the version that actually exercises rowbot/url — 8.5+ uses native `Uri\WhatWg\Url`):

| Resolution | rowbot/url | psr/log | brick/math | Result |
|---|---|---|---|---|
| highest | 4.1.0 | 3.0.2 | 0.13.1 | ✅ all pass, Psalm clean |
| pinned | 4.0.0 | 3.0.2 | 0.9.3 | ✅ all pass |
| pinned | 3.1.7 | 3.0.2 | 0.9.3 | ✅ all pass, Psalm clean |
| `--prefer-lowest` | 3.1.7 | 1.0.0 | 0.8.13 | ✅ all pass |

## Caveat worth deciding on

rowbot/url 3.1.7 emits 10 PHP 8.4 implicit-nullable deprecation *notices* from its own code when loaded (behavior is unaffected; all tests pass). Since it only loads on PHP 8.4 and only when another dependency forces the downgrade, I kept it in the constraint — maximum solver room. If you'd rather not advertise a version that emits deprecations, trimming to `^4.0 || ^4.1` still captures the brick/math flexibility and is a one-line change.

🤖 Generated with Claude Code