### PR TITLE
Fix linguist attribute so HTML test fixtures are excluded from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,7 @@
 /docker export-ignore
 /docker-compose.yml export-ignore
 
-test/* linguist-language=PHP
+# Exclude test files from GitHub's language statistics (** needed to match
+# nested files like test/test-pages/*/source.html, * stops at directories)
+/test/** linguist-vendored
 * text=auto eol=lf


### PR DESCRIPTION
## Why

GitHub currently reports this repo as ~99% HTML because of the ~30 MB of HTML test fixtures under `test/test-pages/`.

`.gitattributes` already tried to address this with `test/* linguist-language=PHP`, but that line has never worked: in `.gitattributes` patterns, `*` does not cross directory boundaries, so it only matched direct children of `test/` (the `*Test.php` files, which are already PHP) and never the nested fixtures like `test/test-pages/lwn-1/source.html`. Verified with `git check-attr`:

```
$ git check-attr linguist-language -- test/test-pages/lwn-1/source.html
test/test-pages/lwn-1/source.html: linguist-language: unspecified
```

## What

Replace the broken line with:

```
/test/** linguist-vendored
```

- `**` matches at any depth, so all fixtures are covered (confirmed via `git check-attr` on nested files; `src/` and root files are unaffected).
- `linguist-vendored` excludes the files from language statistics entirely, which is more honest than relabelling 30 MB of HTML as PHP — the language bar will now reflect the actual library code in `src/`.

Stats update on the next push to the default branch after merging.

## Composer installs (no change needed)

The test directory is already kept out of Composer dist installs: `/test/ export-ignore` has been in `.gitattributes` since #9 and is included in the v4.0.0 release. `git archive HEAD` (what GitHub uses to build the zips Composer downloads) produces 24 files with nothing from `test/`. Only `--prefer-source` (full git clone) installs pull the fixtures, which is inherent to git and can't be avoided.

🤖 Generated with Claude Code